### PR TITLE
Row highlight

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
             android:value="knitgrid.db" />
         <meta-data
             android:name="VERSION"
-            android:value="5" />
+            android:value="6" />
         <meta-data
             android:name="QUERY_LOG"
             android:value="true" />

--- a/app/src/main/java/com/connorlay/knitgrid/models/Pattern.java
+++ b/app/src/main/java/com/connorlay/knitgrid/models/Pattern.java
@@ -14,17 +14,17 @@ public class Pattern extends SugarRecord implements Parcelable {
     private String name;
     private int rows;
     private int cols;
-    private boolean alternating;
+    private boolean showEvenRows;
 
     public Pattern() {
 
     }
 
-    public Pattern(String name, int rows, int columns, boolean alternating) {
+    public Pattern(String name, int rows, int columns, boolean showEvenRows) {
         this.name = name;
         this.rows = rows;
         this.cols = columns;
-        this.alternating = alternating;
+        this.showEvenRows = showEvenRows;
     }
 
     protected Pattern(Parcel in) {
@@ -32,7 +32,7 @@ public class Pattern extends SugarRecord implements Parcelable {
         name = in.readString();
         rows = in.readInt();
         cols = in.readInt();
-        alternating = in.readByte() != 0;
+        showEvenRows = in.readByte() != 0;
     }
 
     @Override
@@ -41,7 +41,7 @@ public class Pattern extends SugarRecord implements Parcelable {
         dest.writeString(name);
         dest.writeInt(rows);
         dest.writeInt(cols);
-        dest.writeByte((byte) (alternating ? 1 : 0));
+        dest.writeByte((byte) (showEvenRows ? 1 : 0));
     }
 
     @Override
@@ -73,8 +73,8 @@ public class Pattern extends SugarRecord implements Parcelable {
         return cols;
     }
 
-    public boolean isAlternating() {
-        return alternating;
+    public boolean showsEvenRows() {
+        return showEvenRows;
     }
 
     public void setName(String name) {
@@ -89,8 +89,8 @@ public class Pattern extends SugarRecord implements Parcelable {
         this.cols = columns;
     }
 
-    public void setAlternating(boolean alternating) {
-        this.alternating = alternating;
+    public void setShowsEvenRows(boolean showEvenRows) {
+        this.showEvenRows = showEvenRows;
     }
 
     public List<StitchPatternRelation> getStitchRelations() {
@@ -98,6 +98,7 @@ public class Pattern extends SugarRecord implements Parcelable {
     }
 
     public void setStitch(Stitch stitch, int row, int column) {
+        // TODO: support editing an existing stitch relation?
         new StitchPatternRelation(this, stitch, row, column).save();
     }
 }

--- a/app/src/main/java/com/connorlay/knitgrid/presenters/PatternPresenter.java
+++ b/app/src/main/java/com/connorlay/knitgrid/presenters/PatternPresenter.java
@@ -17,11 +17,14 @@ public class PatternPresenter implements Parcelable {
     private Stitch[][] mStitchGrid;
     private int mRows, mCols;
     private Pattern mPattern;
+    private boolean mShowEvenRows;
+    private Long mPatternId;
 
-    public PatternPresenter(int rows, int cols) {
+    public PatternPresenter(int rows, int cols, boolean showEvenRows) {
         mRows = rows;
         mCols = cols;
         mStitchGrid = new Stitch[rows][cols];
+        mShowEvenRows = showEvenRows;
     }
 
     public PatternPresenter(Pattern pattern) {
@@ -29,6 +32,8 @@ public class PatternPresenter implements Parcelable {
         mCols = pattern.getColumns();
         mStitchGrid = new Stitch[mRows][mCols];
         mPattern = pattern;
+        mShowEvenRows = pattern.showsEvenRows();
+        mPatternId = pattern.getId();
         populateStitchGrid(pattern);
     }
 
@@ -54,7 +59,7 @@ public class PatternPresenter implements Parcelable {
         dest.writeInt(mRows);
         dest.writeInt(mCols);
         // TODO: there is probably a better way to do this without relying on serializers
-        dest.writeSerializable(mStitchGrid);
+        dest.writeSerializable(mStitchGrid); // TODO: this crashes when hitting the back button from the pattern detail fragment
     }
 
     @Override
@@ -92,6 +97,18 @@ public class PatternPresenter implements Parcelable {
 
     public Pattern getPattern() {
         return mPattern;
+    }
+
+    public boolean showsEvenRows() {
+        return mShowEvenRows;
+    }
+
+    public void setShowsEvenRows(boolean showEvenRows) {
+       mShowEvenRows = showEvenRows;
+    }
+
+    public Long getPatternId() {
+        return mPatternId;
     }
 
     @Override

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,6 @@
     <color name="colorPrimary">#3F51B5</color>
     <color name="colorPrimaryDark">#303F9F</color>
     <color name="colorAccent">#FF4081</color>
+    <color name="cellDefault">#FFFFFF</color>
+    <color name="cellHighlight">#2e7d32</color>
 </resources>


### PR DESCRIPTION
Resolves #3 

Users can click on a cell in `PatternDetailFragment` to highlight all cells up to and including it. If the pattern has `showEvenRows == true` and the row of the clicked cell is even, the cells will highlight from left-to-right, otherwise right-to-left.

The highlight state is saved in shared preferences.
